### PR TITLE
Add padding to chart-qualifiers

### DIFF
--- a/wazimap/static/css/_charts.scss
+++ b/wazimap/static/css/_charts.scss
@@ -19,6 +19,7 @@ uncomment for separate inclusion into embed iframes */
     float: left;
     display: block;
     margin: 0 .5em;
+    padding-top: 1em;
 }
 .census-chart-embed {
     position: relative;


### PR DESCRIPTION
Add `1em` spacing on `chart-qualifier` to eliminate jumbled text.