### PR TITLE
Limit geography_id to levels defined in settings.py

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "env/bin/python"
+}

--- a/wazimap/urls.py
+++ b/wazimap/urls.py
@@ -19,6 +19,8 @@ handler500 = 'census.views.server_error'
 STANDARD_CACHE_TIME = settings.WAZIMAP['cache_secs']
 EMBED_CACHE_TIME = settings.WAZIMAP.get('embed_cache_secs', STANDARD_CACHE_TIME)
 
+GEOGRAPHY_LEVELS = '|'.join(settings.WAZIMAP['levels'].keys())
+PROFILES_GEOGRAPHY_REGEX = r'profiles/(?P<geography_id>[{}]+-\w+)(-(?P<slug>[\w-]+))?'.format(GEOGRAPHY_LEVELS)
 
 urlpatterns = [
     url(
@@ -43,7 +45,7 @@ urlpatterns = [
 
     # e.g. /profiles/province-GT/
     url(
-        regex   = '^profiles/(?P<geography_id>\w+-\w+)(-(?P<slug>[\w-]+))?/$',
+        regex   = '^{}/$'.format(PROFILES_GEOGRAPHY_REGEX),
         view    = cache_page(STANDARD_CACHE_TIME)(GeographyDetailView.as_view()),
         kwargs  = {},
         name    = 'geography_detail',
@@ -60,7 +62,7 @@ urlpatterns = [
 
     # e.g. /profiles/province-GT.json
     url(
-        regex   = '^(embed_data/)?profiles/(?P<geography_id>\w+-\w+)(-(?P<slug>[\w-]+))?\.json$',
+        regex   = '^(embed_data/)?{}\.json/$'.format(PROFILES_GEOGRAPHY_REGEX),
         view    = cache_page(STANDARD_CACHE_TIME)(GeographyJsonView.as_view()),
         kwargs  = {},
         name    = 'geography_json',


### PR DESCRIPTION
On `profiles/` URLs, wazimap assumes anything with a `-` is a geography level e.g. `country-ZA`, `south-africa`, etc.

This PR limits the possible values of `geography_id` to only those defined in the `levels` dictionary in `settings.py`

Hence, if:

```python
    ...
    'levels': {
        'country': {
            'plural': 'countries',
            'children': [],
        }
     }
    ...
```
then:

 + `profiles/country-ZA`, would match,
 + `profiles/countryZA`, will not match (no `-` after `country`), and
 + `profiles/south-africa`, will not match (`south` is not a level even though there is a `-`)
