### PR TITLE
API call to list geo children

### DIFF
--- a/wazimap/urls.py
+++ b/wazimap/urls.py
@@ -107,6 +107,12 @@ urlpatterns = (
         kwargs  = {},
         name    = 'api_geo_parents',
     ),
+    url(
+        regex   = '^api/1.0/geo/(?P<geo_id>\w+-\w+)/children$',
+        view    = cache_page(STANDARD_CACHE_TIME)(GeoAPIView.as_view()),
+        kwargs  = {'action': 'children'},
+        name    = 'api_geo_children',
+    ),
 
     # TODO enable this see: https://github.com/Code4SA/censusreporter/issues/31
     #url(

--- a/wazimap/urls.py
+++ b/wazimap/urls.py
@@ -107,6 +107,7 @@ urlpatterns = (
         kwargs  = {},
         name    = 'api_geo_parents',
     ),
+    
     url(
         regex   = '^api/1.0/geo/(?P<geo_id>\w+-\w+)/children$',
         view    = cache_page(STANDARD_CACHE_TIME)(GeoAPIView.as_view()),

--- a/wazimap/views.py
+++ b/wazimap/views.py
@@ -349,7 +349,7 @@ class GeographyCompareView(TemplateView):
 
 class GeoAPIView(View):
     """
-    View that lists things about geos. Currently just parents.
+    View that lists things about geos. Currently parents and children.
     """
     def get(self, request, geo_id, *args, **kwargs):
         try:
@@ -360,6 +360,16 @@ class GeoAPIView(View):
 
         parents = [g.as_dict() for g in geo.ancestors()]
         return render_json_to_response(parents)
+
+    def children(self, request, geo_id, *args, **kwargs):
+        try:
+            level, code = geo_id.split('-', 1)
+            geo = geo_data.get_geography(code, level)
+        except (ValueError, LocationNotFound):
+            raise Http404
+
+        children = [g.as_dict() for g in geo.children()]
+        return render_json_to_response(children)
 
 
 class TableDetailView(TemplateView):


### PR DESCRIPTION
Just as we can list parents for a geo using `/api/1.0/geo/<geo_id>/parents` ..

this PR allows us to list children in the same manner `/api/1.0/geo/<geo_id>/children`







####  API call will be used on `Dominion` project ####

