### PR TITLE
[Bug] Fix get_stat_data ordering by descending total

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ install_requires = [
     'django-pipeline>=1.6.4',
     'django-sass-processor>=0.5.4',
     'ecdsa>=0.11',
-    'futures>=3.0.4',
     'libsass>=0.13.1',
     'paramiko>=1.12.3,<2',
     'psycopg2>=2.5.2',

--- a/wazimap/models/data.py
+++ b/wazimap/models/data.py
@@ -35,7 +35,7 @@ from django.dispatch import receiver
 from itertools import groupby
 from wazimap.data.base import Base
 from wazimap.data.utils import get_session, capitalize, percent as p, add_metadata, current_context
-from sqlalchemy import Column, String, Table, or_, and_, func
+from sqlalchemy import Column, String, Table, or_, and_, func, text
 from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.orm import class_mapper
 import sqlalchemy.types
@@ -855,7 +855,7 @@ class FieldTable(DataTable):
 
             if attr == 'total':
                 if is_desc:
-                    attr = attr + ' DESC'
+                    attr = text(attr + ' DESC')
             else:
                 attr = getattr(db_model, attr)
                 if is_desc:


### PR DESCRIPTION
`get_stat_method` throws an error on adding `order_by => -total` parameter (descending total). The error is caused by the updated `SqlAchemy v1.3.5`

`Can't resolve label reference for ORDER BY / GROUP BY. Textual SQL expression 'total DESC' should be explicitly declared as text('total DESC')`

This PR fixes the compile error.
