### PR TITLE
[HOTFIX] Upgrade deprecated MIDDLEWARE style

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "env/bin/python3"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "env/bin/python3"
+}

--- a/wazimap/middleware.py
+++ b/wazimap/middleware.py
@@ -3,10 +3,24 @@ from django.http.response import HttpResponsePermanentRedirect
 
 
 class RedirectMiddleware(object):
-    def process_request(self, request):
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # One-time configuration and initialization.
+
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+
         host = request.get_host()
 
         # redirect www.foo.com to foo.com?
         if settings.STRIP_WWW and host.startswith("www."):
             redirect_url = '%s://%s%s' % (request.scheme, host[4:], request.get_full_path())
             return HttpResponsePermanentRedirect(redirect_url)
+
+        response = self.get_response(request)
+
+        # Code to be executed for each request/response after
+        # the view is called.
+
+        return response


### PR DESCRIPTION
Fixes the following error:

```
web_1  | Run 'python manage.py migrate' to apply them.
web_1  | September 06, 2019 - 15:51:09
web_1  | Django version 1.11.24, using settings 'takwimu.settings'
web_1  | Starting development server at http://0.0.0.0:8000/
web_1  | Quit the server with CONTROL-C.
web_1  | Unhandled exception in thread started by <function check_errors.<locals>.wrapper at 0x7fa9d9dbe950>
web_1  | Traceback (most recent call last):
web_1  |   File "/usr/local/lib/python3.7/site-packages/django/utils/autoreload.py", line 228, in wrapper
web_1  |     fn(*args, **kwargs)
web_1  |   File "/usr/local/lib/python3.7/site-packages/django/core/management/commands/runserver.py", line 146, in inner_run
web_1  |     handler = self.get_handler(*args, **options)
web_1  |   File "/usr/local/lib/python3.7/site-packages/django/contrib/staticfiles/management/commands/runserver.py", line 28, in get_handler
web_1  |     handler = super(Command, self).get_handler(*args, **options)
web_1  |   File "/usr/local/lib/python3.7/site-packages/django/core/management/commands/runserver.py", line 67, in get_handler
web_1  |     return get_internal_wsgi_application()
web_1  |   File "/usr/local/lib/python3.7/site-packages/django/core/servers/basehttp.py", line 47, in get_internal_wsgi_application
web_1  |     return import_string(app_path)
web_1  |   File "/usr/local/lib/python3.7/site-packages/django/utils/module_loading.py", line 20, in import_string
web_1  |     module = import_module(module_path)
web_1  |   File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
web_1  |     return _bootstrap._gcd_import(name[level:], package, level)
web_1  |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
web_1  |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
web_1  |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
web_1  |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
web_1  |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
web_1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
web_1  |   File "/usr/local/lib/python3.7/site-packages/wazimap/wsgi.py", line 15, in <module>
web_1  |     application = get_wsgi_application()
web_1  |   File "/usr/local/lib/python3.7/site-packages/django/core/wsgi.py", line 14, in get_wsgi_application
web_1  |     return WSGIHandler()
web_1  |   File "/usr/local/lib/python3.7/site-packages/django/core/handlers/wsgi.py", line 151, in __init__
web_1  |     self.load_middleware()
web_1  |   File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 82, in load_middleware
web_1  |     mw_instance = middleware(handler)
web_1  | TypeError: RedirectMiddleware() takes no arguments
web_1  | 2019-09-06 15:51:53,530 INFO apps 10 140448496822016 Wazimap found GDAL version 2.1.2
web_1  | System check identified some issues:
```
